### PR TITLE
docs: align planet tasks with design doc

### DIFF
--- a/TASK_TRACKING.md
+++ b/TASK_TRACKING.md
@@ -1,0 +1,140 @@
+# TASK TRACKING
+
+Consolidated view of active task briefs under `tasks/2025-09-21`. Update checkboxes as work progresses.
+
+## Core Infrastructure & Progression Systems
+- [ ] **T-001** – Planet definition alignment & discovery log audit
+- [ ] **T-002** – Fuel bucket registry wiring
+- [ ] **T-003** – Terrablender constant definitions
+- [ ] **T-004** – JSON validation tooling
+- [ ] **T-005** – Planet registry overrides + config merge
+- [ ] **T-006** – `/chex dumpPlanets` command implementation
+- [ ] **T-007** – Travel graph validation utilities
+- [ ] **T-008** – Player tier capability + sync
+- [ ] **T-009** – Fuel registry fallbacks & fluids
+
+## Pandora (Tier 3)
+- [ ] **T-020** – Dimension JSON & twilight atmosphere
+- [ ] **T-021** – Biome definitions
+- [ ] **T-022** – Pandorite block family
+- [ ] **T-023** – Flora generation (fungal towers, kelp, cloud islands)
+- [ ] **T-024** – Fauna (glowbeast, sporeflies, sky grazer, cliff hunter)
+- [ ] **T-025** – Boss suite culminating in Worldheart Avatar
+- [ ] **T-026** – Hazards, ambience, audio polish
+- [ ] **T-027** – GTCEu ore integration
+
+## Arrakis (Tier 4)
+- [ ] **T-030** – Dimension template & sandstorm environment
+- [ ] **T-031** – Biomes & climate bands
+- [ ] **T-032** – Block set (arrakite, spice nodes, etc.)
+- [ ] **T-033** – Feature generation (dunes, tunnels, geysers)
+- [ ] **T-034** – Flora set (cactus, ice reeds, shrubs)
+- [ ] **T-035** – Fauna (sandworm juvenile, storm hawks, gatherers)
+- [ ] **T-036** – Sand Emperor boss encounter
+- [ ] **T-037** – Environmental hazards & audio
+
+## Alpha Centauri A
+- [ ] **T-040** – Dimension layout (photosphere, corona)
+- [ ] **T-041** – Hazard systems (radiation, flares)
+- [ ] **T-042** – Structures (solar collectors, flux pylons)
+- [ ] **T-043** – Entities (plasma wraiths, engineer drones)
+- [ ] **T-044** – Stellar Avatar boss fight
+
+## Kepler-452b
+- [ ] **T-050** – Biome set (forest, highlands, rivers, meadow, scrub)
+- [ ] **T-051** – Tree generation + canopy assets
+- [ ] **T-052** – Fauna (grazers, flutterwings, stalkers)
+- [ ] **T-053** – Verdant Colossus boss arena
+
+## Aqua Mundus (Tier 5)
+- [ ] **T-060** – Water world dimension setup
+- [ ] **T-061** – Mechanics (pressure, oxygen, thermal)
+- [ ] **T-062** – Blocks/features (vent basalt, luminous kelp)
+- [ ] **T-063** – Fauna (luminfish, drones, leviathan, jelly)
+- [ ] **T-064** – Ocean Sovereign boss
+- [ ] **T-065** – Audio/visual polish (biolum glow, ambience)
+
+## Inferno Prime (Tier 6)
+- [ ] **T-070** – Biomes (lava seas, ash wastes, etc.)
+- [ ] **T-071** – Features (magma geysers, basalt pillars)
+- [ ] **T-072** – Fauna (ash crawlers, fire wraiths, magma hopper)
+- [ ] **T-073** – Infernal Sovereign boss
+- [ ] **T-074** – Environmental hazards & sky effects
+
+## Crystalis (Tier 8)
+- [ ] **T-080** – Biomes (Diamond Fields, Frosted Plains, etc.)
+- [ ] **T-081** – Block set (cryostone variants, glacial glass, vents)
+- [ ] **T-082** – Flora & fauna roster per biome
+- [ ] **T-083** – Cryo Monarch boss encounter
+- [ ] **T-084** – Hazards (frostbite, geysers, auroras)
+
+## Stormworld (Tier 9)
+- [ ] **T-090** – Layered biome configuration
+- [ ] **T-091** – Gravity/lightning/pressure mechanics
+- [ ] **T-092** – Blocks & features (cloud blocks, ion spires, fulgurite)
+- [ ] **T-093** – Entities & mini-bosses suite
+- [ ] **T-094** – Stormlord Colossus encounter
+
+## Ringworld Megastructure (Tier 11)
+- [ ] **T-100** – Strip generator & biome zoning
+- [ ] **T-101** – Structures & mini-boss arenas
+- [ ] **T-102** – Fauna/construct entities + travel nodes
+- [ ] **T-103** – Guardian Prime boss fight
+
+## Exotica (Tier 12)
+- [ ] **T-110** – Dimension & chromatic biomes
+- [ ] **T-111** – Blocks/features (Exotite, prism flora, resonance sand)
+- [ ] **T-112** – Fauna roster (chroma grazers, phase stalkers, etc.)
+- [ ] **T-113** – Reality Breaker + mini-boss encounters
+- [ ] **T-114** – Hazards (spatial distortion, gravity shifts)
+
+## Torus World (Tier 13)
+- [ ] **T-120** – Toroidal generator & biome setup
+- [ ] **T-121** – Blocks/features (torium alloys, radiant panels)
+- [ ] **T-122** – Entities & mini-bosses
+- [ ] **T-123** – Torus Warden boss encounter
+- [ ] **T-124** – Hazards & progression hooks
+
+## Hollow World (Tier 14)
+- [ ] **T-130** – Inverted dimension & biome definitions
+- [ ] **T-131** – Blocks/features (hollowstone, void crystals, stalactites)
+- [ ] **T-132** – Fauna & mini-boss roster
+- [ ] **T-133** – Hollow Tyrant boss fight
+- [ ] **T-134** – Hazards & ambience (darkness, void chasms, radiation)
+
+## Shattered Dyson Swarm (Tier 15)
+- [ ] **T-140** – Zero-G dimension & biomes
+- [ ] **T-141** – Blocks/structures (panels, nodes, scaffolds, relays)
+- [ ] **T-142** – Entities & mini-bosses suite
+- [ ] **T-143** – Dyson Apex boss encounter
+- [ ] **T-144** – Hazards & progression (radiation, debris, vacuum)
+
+## Neutron Star Forge (Tier 16–17)
+- [ ] **T-150** – Dimension & biome configuration
+- [ ] **T-151** – Blocks/features (plasma glass, strangelet stone, shelters)
+- [ ] **T-152** – Entities & mini-bosses
+- [ ] **T-153** – Forge Star Sovereign boss encounter
+- [ ] **T-154** – Hazards & progression (magnetic storms, gravity wells)
+
+## Cross-Planet Systems & GTCEu Integration
+- [ ] **T-200** – Mineral config alignment with design doc
+- [ ] **T-201** – Fallback processing recipes
+- [ ] **T-202** – Mineral config reload command
+- [ ] **T-210** – Boss controller framework
+- [ ] **T-211** – Boss core matrix implementation
+- [ ] **T-212** – Suit hazard system
+- [ ] **T-213** – Launch validation enhancements
+- [ ] **T-220** – Client tooltips & UX
+- [ ] **T-221** – Launch messaging UX polish
+- [ ] **T-222** – JEI integration
+- [ ] **T-223** – Ambience & soundscape work
+- [ ] **T-224** – Skyboxes & visual filters
+
+## Documentation, QA & Release
+- [ ] **T-230** – Documentation updates
+- [ ] **T-231** – Sample config authoring
+- [ ] **T-232** – README refresh
+- [ ] **T-233** – Changelog maintenance
+- [ ] **T-240** – Smoke test scripting
+- [ ] **T-241** – Manual QA checklist
+- [ ] **T-242** – Release packaging prep

--- a/tasks/2025-09-21/T-025_pandora-bosses.md
+++ b/tasks/2025-09-21/T-025_pandora-bosses.md
@@ -1,15 +1,16 @@
 # T-025 Pandora Boss Encounters
 
 **Goal**
-- Design and implement Pandora boss encounters (Spore Tyrant, Cliff Hunter Alpha, Deep-Sea Siren, Molten Behemoth, Sky Sovereign) including arenas, abilities, loot cores.
+- Design and implement Pandora boss encounters (Spore Tyrant, Cliff Hunter Alpha, Deep-Sea Siren, Molten Behemoth, Storm Roc) culminating in the **Worldheart Avatar** main fight with bespoke arenas, abilities, and loot cores.
 
 **Scope**
-- Entity/boss classes, arenas (structures/datapack), loot tables.
-- Progression unlock hooks for GT tiers.
+- Entity/boss classes for all mini-bosses plus the Worldheart Avatar.
+- Arena structures/datapack layouts per biome encounter and the central floating-island finale.
+- Loot tables and GT progression hooks (Biolume Core, Pandoran Heartseed, weapon drops).
 
 **Acceptance**
-- Each boss fight playable end-to-end with reward item(s).
-- Loot cores integrate with progression gating.
+- Each boss fight plays end-to-end with tuned mechanics and reward drops (spore, cliff, ocean, volcanic cores, Heartseed weapon set).
+- Pandoran Heartseed unlock + Biolume Core wiring into GT tier gating documented.
 - `./gradlew check` passes; document balance/open issues in notes.
 
 **Checklist**

--- a/tasks/2025-09-21/T-081_crystalis-blocks.md
+++ b/tasks/2025-09-21/T-081_crystalis-blocks.md
@@ -1,13 +1,15 @@
 # T-081 Crystalis Blocks
 
 **Goal**
-- Implement Crystalis blocks (crystal lattice, cryo ice, frost glass, pressure ice) with visual shine.
+- Implement the full Crystalis block set: cryostone variants (base/cracked/mossy/permafrost), glacial glass, geyser stone + frozen vent ice, pressure crystals, prism ice spires, and crystal lattice decorative blocks with shimmering visuals.
 
 **Scope**
-- Block registrations/assets, shaders if needed.
+- Block registrations, blockstate/models/loot/recipes across `common` + `forge` resources.
+- Optional shader hooks or render layers for translucent/animated materials (glacial glass, pressure crystals).
 
 **Acceptance**
-- Blocks registered with textures/models; `./gradlew check` passes.
+- All listed block families available in-game with crafting/loot parity; biome palettes reference them.
+- Render layers validated for transparency/shine; `./gradlew check` passes.
 
 **Checklist**
 - [ ] `bash scripts/cloud_bootstrap.sh`

--- a/tasks/2025-09-21/T-082_crystalis-flora-fauna.md
+++ b/tasks/2025-09-21/T-082_crystalis-flora-fauna.md
@@ -1,13 +1,16 @@
 # T-082 Crystalis Flora & Fauna
 
 **Goal**
-- Implement Crystalis flora (crystal spires, frost blooms) and fauna (snow striders, cryo drakes).
+- Implement Crystalis flora (Crystal Bloom, Frost Moss, Frostcaps, Icicle Spires, pressure sponges) and fauna (Crystal Grazers, Shardlings, Frost Hares, Ice Stalkers, Mist Wraiths, Vent Crawlers, Cliff Raptors, Snow Gargoyles, Pressure Leviathans, Abyss Drifters) matching biome assignments.
 
 **Scope**
-- Blocks/entities, loot tables, spawn rules.
+- Block/item definitions for flora interactables plus configured/placed feature hooks.
+- Entity registrations, AI behaviours, models/animations, spawn rules, and loot tables delivering GT materials.
+- Mini-boss trigger hooks feeding into boss matrix where needed (e.g., Crystal Colossus allies).
 
 **Acceptance**
-- Flora/ fauna behave per design; drops enable cryogenic tech.
+- Flora generates and interacts (lights, freezing behaviour) per design doc references.
+- Each fauna type spawns in correct biome bands with drops mapped to GT cryogenic progression (shards, fur, fangs, vapor, etc.).
 - `./gradlew check` passes.
 
 **Checklist**

--- a/tasks/2025-09-21/T-083_crystalis-boss.md
+++ b/tasks/2025-09-21/T-083_crystalis-boss.md
@@ -1,13 +1,16 @@
 # T-083 Crystalis Boss
 
 **Goal**
-- Build Cryo Monarch boss with freeze beam + minions; drop Frozen Heart unlocking cryogenics/superconductors.
+- Build the multi-phase Cryo Monarch boss (Shard Storm, Frozen Domain, Glacial Collapse) with minion support and Frozen Heart/Shardblade/Monarch Core rewards for cryogenic progression.
 
 **Scope**
-- Boss entity, arena, loot integration.
+- Boss entity implementation (phase controller, teleporting, ice shard barrages, arena collapse logic).
+- Frozen cathedral arena structure/datapack and scripted icicle hazards.
+- Loot integration: Frozen Heart tier unlock, Shardblade weapon, Monarch Core for GT recipes.
 
 **Acceptance**
-- Fight playable; reward ties into GT progression; `./gradlew check` passes.
+- Boss fight executes all phases with telegraphs, minion summons, terrain destruction matching design doc.
+- Rewards distributed correctly and progression hooks documented/tested; `./gradlew check` passes.
 
 **Checklist**
 - [ ] `bash scripts/cloud_bootstrap.sh`

--- a/tasks/2025-09-21/T-084_crystalis-hazards.md
+++ b/tasks/2025-09-21/T-084_crystalis-hazards.md
@@ -1,13 +1,15 @@
 # T-084 Crystalis Hazards
 
 **Goal**
-- Implement cryogenic hazards (freeze damage, slippery surfaces, snow blindness) and blue aurora sky.
+- Implement cryogenic hazards (ambient frostbite debuff, cryo geyser eruptions that encase players, low-traction ice, snow blindness) plus aurora skybox + blizzard FX.
 
 **Scope**
-- Hazard systems, particle/visual effects.
+- Hazard systems tied to suit tier checks (frostbite tick, pressure depth damage over time).
+- Particle/visual effects for auroras, blizzards, geyser eruptions, frozen overlays.
 
 **Acceptance**
-- Hazards activate correctly; visuals match design; `./gradlew check` passes.
+- Hazards activate in appropriate biomes/layers with tunable configs and respect suit mitigation.
+- Visual/ambient effects (auroras, blizzards, geyser steam) align with design doc references; `./gradlew check` passes.
 
 **Checklist**
 - [ ] `bash scripts/cloud_bootstrap.sh`

--- a/tasks/2025-09-21/T-091_stormworld-mechanics.md
+++ b/tasks/2025-09-21/T-091_stormworld-mechanics.md
@@ -1,13 +1,16 @@
 # T-091 Stormworld Mechanics
 
 **Goal**
-- Implement Stormworld mechanics (variable gravity, lightning strikes, pressure crush near depths).
+- Implement Stormworld systemic mechanics: layer-based gravity scaling (1.5g surface, near-zero in vortices), omnipresent lightning storms with shield checks, hunger drain acceleration, and metallic-hydrogen crushing pressure requiring advanced suits.
 
 **Scope**
-- Hazard/mechanic systems, suit checks.
+- Hazard/mechanic systems tied to player tier/suit resistances (electric, pressure, gravity).
+- Weather + lightning scheduler, wind push forces, hunger drain modifiers, and depth pressure calculations.
+- Telemetry/logging hooks for tuning.
 
 **Acceptance**
-- Mechanics activate per layer; respect suit tiers; `./gradlew check` passes.
+- Mechanics activate per layer with configurable intensities and respect suit tiers; hunger/pressure/electric effects stack correctly.
+- Logging/telemetry available for balancing; `./gradlew check` passes.
 
 **Checklist**
 - [ ] `bash scripts/cloud_bootstrap.sh`

--- a/tasks/2025-09-21/T-092_stormworld-features.md
+++ b/tasks/2025-09-21/T-092_stormworld-features.md
@@ -1,13 +1,15 @@
 # T-092 Stormworld Blocks & Features
 
 **Goal**
-- Add storm cloud blocks, charge collectors, lightning rods, hydrogen pools and related features.
+- Add Stormworld block/feature set: stormstone + condensed variants, reforming cloud blocks, ion spires, fulgurite glass, charged crystals, metallic hydrogen pools, and lightning rod/charge collector infrastructure.
 
 **Scope**
-- Block registrations/assets, feature configs, worldgen integration.
+- Block registrations/assets, feature configs, biome modifier wiring for each layer (Upper Atmosphere → cloud blocks, Storm Bands → ion spires, Lightning Fields → fulgurite/charged crystals, Depths → metallic hydrogen pools).
+- Interaction logic (cloud block regeneration, charged crystal power bursts) as described in design doc.
 
 **Acceptance**
-- Features generate; blocks usable in progression; `./gradlew check` passes.
+- Features generate in intended layers with density per design doc (ion spires in storm bands, fulgurite/charged crystals in lightning fields, metallic hydrogen pools in depths).
+- Interactive behaviour (cloud block regen, charge collectors capturing lightning) validated; `./gradlew check` passes.
 
 **Checklist**
 - [ ] `bash scripts/cloud_bootstrap.sh`

--- a/tasks/2025-09-21/T-093_stormworld-entities.md
+++ b/tasks/2025-09-21/T-093_stormworld-entities.md
@@ -1,14 +1,16 @@
 # T-093 Stormworld Entities
 
 **Goal**
-- Implement tempest serpents, storm titans, aerial behemoths with flight AI and lightning abilities.
+- Implement Stormworld fauna suite: Sky Whales, Cloud Rays, Storm Drakes, Gust Wraiths, Fulminators, Spark Beetles, Eye Serpents, Calm Spirits, Hydrogen Beasts, Pressure Horrors plus mini-boss entities (Aerial Behemoth, Tempest Serpent, Storm Titan, Cyclone Guardian, Depth Leviathan).
 
 **Scope**
-- Entity classes, AI, loot tables, assets.
+- Entity classes, AI, animation controllers, loot tables, and assets for each airborne/pressure-adapted creature.
+- Layer-specific spawn rules with environmental behaviours (wind push, lightning discharge, pressure resistance).
+- Mini-boss ability scripts and integration with boss core drop tables.
 
 **Acceptance**
-- Entities behave per design; drops feed exotic superconductors.
-- `./gradlew check` passes.
+- Entities exhibit required behaviours (flight paths, lightning discharge, pressure effects) and spawn only within their biome layers.
+- Drops align with GT progression items (storm essence, charged horns, hydrogen hearts, etc.); `./gradlew check` passes.
 
 **Checklist**
 - [ ] `bash scripts/cloud_bootstrap.sh`

--- a/tasks/2025-09-21/T-094_stormworld-boss.md
+++ b/tasks/2025-09-21/T-094_stormworld-boss.md
@@ -1,13 +1,16 @@
 # T-094 Stormworld Boss Encounter
 
 **Goal**
-- Implement Stormlord Colossus boss with lightning phases and Stormheart reward unlocking exotic superconductors.
+- Implement the Stormlord Colossus multi-phase encounter (Thunder → Tempest → Cataclysm) with lightning/tornado mechanics and Stormheart/Thundermaul/Colossus Core rewards unlocking exotic superconductors.
 
 **Scope**
-- Boss entity, arena, loot progression.
+- Boss entity logic (chain lightning, tornado summons, shockwave knockback) with telegraphs and resist checks.
+- Vortex arena structure + scripted lightning strike network.
+- Loot progression wiring: Stormheart tier unlock, Thundermaul weapon, Colossus Core for HV transformer recipes.
 
 **Acceptance**
-- Fight playable; reward ties into progression; `./gradlew check` passes.
+- Encounter runs through all three phases with lightning cadence matching design doc.
+- Drops correctly awarded and integrated into progression configs; `./gradlew check` passes.
 
 **Checklist**
 - [ ] `bash scripts/cloud_bootstrap.sh`

--- a/tasks/2025-09-21/T-100_ringworld-generator.md
+++ b/tasks/2025-09-21/T-100_ringworld-generator.md
@@ -1,14 +1,16 @@
 # T-100 Ringworld Generator & Wrap Hooks
 
 **Goal**
-- Implement strip-based chunk generator for ringworld with wrap hooks and natural/urban zone layout.
+- Implement strip-based chunk generator for the Ringworld with wrap hooks and biome zoning matching design doc (Natural: Ice Fields, Dust Belts, Low-Gravity Meadows, Shadowed Rims; Urban: Habitation Plains, Arcology Districts, Sunline Boulevard, Maintenance Tunnels, Edge Trenches).
 
 **Scope**
-- Generator classes, wrap hooks, biome mapping.
+- Custom chunk generator/density functions for toroidal strip layout, including gravity band metadata.
+- Wrap hooks ensuring seamless longitude transitions.
+- Biome band mapping + data-driven zone assignments feeding natural vs urban groups and GregTech ore layers.
 
 **Acceptance**
-- Ringworld terrain generates with band limits; wrap logic works.
-- `./gradlew check` passes.
+- Terrain produces expected alternating strips (visual + debug logging) for each listed zone with correct gravity modifiers.
+- Wrap logic validated (player circumnavigation) without seams; `./gradlew check` passes.
 
 **Checklist**
 - [ ] `bash scripts/cloud_bootstrap.sh`

--- a/tasks/2025-09-21/T-101_ringworld-structures.md
+++ b/tasks/2025-09-21/T-101_ringworld-structures.md
@@ -1,13 +1,16 @@
 # T-101 Ringworld Structures
 
 **Goal**
-- Add ringworld structures (arc scenery anchors, maintenance shafts, command nodes).
+- Add Ringworld structures: natural zone set pieces (ice field glaciers, dust belt ruins, meadow float pads, shadowed fungal hives) and urban constructs (habitation arcologies, neon towers, sunline reflector strips, maintenance shafts, edge trench fortifications) supporting mini-boss arenas (Ice Warden, Dust Colossus, Meadow Leviathan, Shadow Revenant, Arcology Warlord, Neon Sentinel, Heliolith, Tunnel Overseer, Trench Horror).
 
 **Scope**
-- Structure templates, processors, placement integration.
+- Structure templates/processors for each biome grouping including boss arenas and loot tables.
+- Placement integration via structure sets/biome modifiers tuned per zone.
+- Hookups for collapsing debris/falling hazard scripts referenced in design doc.
 
 **Acceptance**
-- Structures generate within band zoning; `./gradlew :forge:runData` + `./gradlew check` pass.
+- Structures spawn in correct biome strips with rotation/spacing validated; boss arenas trigger encounters as expected.
+- `./gradlew :forge:runData` + `./gradlew check` pass; documentation of any TODO FX.
 
 **Checklist**
 - [ ] `bash scripts/cloud_bootstrap.sh`

--- a/tasks/2025-09-21/T-102_ringworld-entities.md
+++ b/tasks/2025-09-21/T-102_ringworld-entities.md
@@ -1,14 +1,16 @@
 # T-102 Ringworld Entities
 
 **Goal**
-- Implement guardian drones, habitat fauna, shadow revenants with travel node integration.
+- Implement Ringworld fauna + constructs: Glacial Grazers, Polar Drakes, Sand Striders, Dust Phantoms, Float Beasts, Sky Flitters, Shadow Hunters, Fungal Shamblers, Scavengers, Hover Beetles, Security Drones, Alloy Guardians, Light Moths, Solar Drones, Worker Drones, Repair Spiders, Alloy Serpents, Edge Beasts along with mini-boss entities (Ice Warden, Dust Colossus, Meadow Leviathan, Shadow Revenant, Arcology Warlord, Neon Sentinel, Heliolith, Tunnel Overseer, Trench Horror) and travel node integration.
 
 **Scope**
-- Entity classes, AI, loot, spawn rules.
+- Entity classes, AI, animations, loot tables, spawn rules for organic + construct mobs across natural/urban zones.
+- Mini-boss ability scripts tied to loot core drops aligning with GT unlocks.
+- Travel node systems linking maintenance tunnels/arcology hubs per design doc.
 
 **Acceptance**
-- Entities function in natural/urban zones; travel nodes interact as planned.
-- `./gradlew check` passes.
+- Entities spawn only in configured zones with correct behaviour (hover, low-gravity float, shadow stealth, drone patrols).
+- Mini-boss encounters drop appropriate cores and integrate with progression; travel nodes operational; `./gradlew check` passes.
 
 **Checklist**
 - [ ] `bash scripts/cloud_bootstrap.sh`

--- a/tasks/2025-09-21/T-103_ringworld-boss.md
+++ b/tasks/2025-09-21/T-103_ringworld-boss.md
@@ -1,13 +1,16 @@
 # T-103 Ringworld Boss Encounter
 
 **Goal**
-- Implement Guardian Prime multi-stage boss in central hub and Prime Core reward unlocking nanomaterials/robotics.
+- Implement the Guardian Prime multi-stage boss (Defense Protocol → Siege Mode → Fail-safe Override) in the central control hub with Prime Core/Guardian’s Blade/Nano Circuit Core rewards unlocking nanomaterials/robotics.
 
 **Scope**
-- Boss entity, arena structure, loot/progression ties.
+- Boss entity behaviour: drone summons, rotating shields, plasma beams, platform collapse scripting.
+- Central hub arena structure + destructible platform logic.
+- Loot/progression ties for Prime Core, Guardian’s Blade, Nano Circuit Core.
 
 **Acceptance**
-- Fight playable; reward integrates progression; `./gradlew check` passes.
+- All three phases run with proper telegraphs and arena destruction; drone summons/hazards match design doc.
+- Rewards integrate into GT progression configs; `./gradlew check` passes.
 
 **Checklist**
 - [ ] `bash scripts/cloud_bootstrap.sh`

--- a/tasks/2025-09-21/T-110_exotica-dimension-biomes.md
+++ b/tasks/2025-09-21/T-110_exotica-dimension-biomes.md
@@ -1,0 +1,21 @@
+# T-110 Exotica Dimension & Biomes
+
+**Goal**
+- Define the Exotica dimension (chromatic haze, variable gravity) and biome set (Chroma Steppes, Resonant Dunes, Quantum Glades, Fractal Forest, Prism Canyons) per the design document.
+
+**Scope**
+- Dimension JSON/noise settings capturing chromatic skybox, spatial distortion visuals, gravity toggles.
+- Biome JSONs with color-cycling fog, ambience, weather, and surface builders for each listed biome.
+- Biome tag curation for ore injection and feature routing.
+
+**Acceptance**
+- Datapack loads without errors; each biome presents intended colors/fog and is reachable via debug worldgen.
+- `./gradlew :forge:runData` + `./gradlew check` pass.
+
+**Checklist**
+- [ ] `bash scripts/cloud_bootstrap.sh`
+- [ ] Author dimension/biome files
+- [ ] `./gradlew :forge:runData`
+- [ ] `./gradlew check`
+- [ ] Log entry `progress/stepXX_exotica_biomes.md` + `PROGRESS_PROMPTS.md`
+- [ ] Open PR referencing this task file

--- a/tasks/2025-09-21/T-111_exotica-blocks-features.md
+++ b/tasks/2025-09-21/T-111_exotica-blocks-features.md
@@ -1,0 +1,21 @@
+# T-111 Exotica Blocks & Features
+
+**Goal**
+- Implement Exotica block families (Exotite, Quantum Crystal, Chromatic Grass/Prismatic Soil, Resonant Sand/Harmonic Stone, Phase Blocks, Fractal Bark/Recursive Leaves, Prism Rock/Crystal Lattices) and associated world features (Prism Trees, Color Reeds, Echo Cacti, Quantum Saplings, Fractal Trees, Light Vines).
+
+**Scope**
+- Block registrations, blockstates/models/loot/recipes with animated/colour-shifting render layers where needed.
+- Configured/placed features for flora with distortion behaviours (phase blocks toggling solidity, color-cycling foliage).
+- Integration hooks for resonance sounds/particle systems referenced in design doc.
+
+**Acceptance**
+- Blocks and features appear in appropriate biomes with expected visuals/behaviours (colour cycling, sound-emitting sand).
+- `./gradlew :forge:runData` + `./gradlew check` pass.
+
+**Checklist**
+- [ ] `bash scripts/cloud_bootstrap.sh`
+- [ ] Implement blocks/features + assets
+- [ ] `./gradlew :forge:runData`
+- [ ] `./gradlew check`
+- [ ] Log entry `progress/stepXX_exotica_features.md` + `PROGRESS_PROMPTS.md`
+- [ ] Open PR referencing this task file

--- a/tasks/2025-09-21/T-112_exotica-fauna.md
+++ b/tasks/2025-09-21/T-112_exotica-fauna.md
@@ -1,0 +1,21 @@
+# T-112 Exotica Fauna Implementation
+
+**Goal**
+- Implement Exotica fauna roster: Chroma Grazers, Spectral Hares, Tone Beasts, Sonic Drifters, Phase Stalkers, Echo Wisps, Fractal Crawlers, Pattern Serpents, Prism Serpents, Rainbow Mantises with biome-appropriate behaviours and GT-focused drops.
+
+**Scope**
+- Entity registrations, AI/animation controllers, spawn rules, and loot tables for listed mobs.
+- Behaviour hooks for phasing/teleportation, resonance sound pulses, low-gravity movement, and colour-shift shaders per design doc.
+- Drop integration to GT photonics/quantum chains (prism hides, spectral fur, resonant bones, light essence, fractal dust, prismatic wings).
+
+**Acceptance**
+- Each fauna type spawns in its intended biome with signature behaviour (phase blink, resonance knockback, colour shimmer) and drops mapped to GT recipes.
+- `./gradlew check` passes; note any animation TODOs in progress log.
+
+**Checklist**
+- [ ] `bash scripts/cloud_bootstrap.sh`
+- [ ] Implement fauna + assets
+- [ ] `./gradlew :common:spotlessApply :forge:spotlessApply`
+- [ ] `./gradlew check`
+- [ ] Log entry `progress/stepXX_exotica_fauna.md` + `PROGRESS_PROMPTS.md`
+- [ ] Open PR referencing this task file

--- a/tasks/2025-09-21/T-113_exotica-bosses.md
+++ b/tasks/2025-09-21/T-113_exotica-bosses.md
@@ -1,0 +1,21 @@
+# T-113 Exotica Boss Encounters
+
+**Goal**
+- Implement Exotica boss suite: biome mini-bosses (Prism Colossus, Dune Siren, Quantum Beast, Fractal Horror, Prism Seraph) and the multi-phase Reality Breaker fight (Fractal Division → Quantum Distortion → Prismatic Collapse) with loot cores/hearts per design doc.
+
+**Scope**
+- Entity/boss classes, arena structures (resonant dunes amphitheatre, quantum glade arenas, fractal forest dome, prism canyon terraces) and scripted abilities (laser refractors, resonance shockwaves, teleporting clones, prismatic spears).
+- Loot table integration delivering Prism/Resonant/Quantum/Fractal/Seraph cores plus Exotic Heart, Fractablade, Breaker Core progression hooks.
+- Progression wiring into boss core matrix + GT unlock config.
+
+**Acceptance**
+- Each mini-boss encounter functions with arena hazards and drops the correct core; Reality Breaker runs all phases with spatial distortion effects and rewards.
+- `./gradlew :forge:runData` (for structures) + `./gradlew check` pass; document outstanding FX tuning if any.
+
+**Checklist**
+- [ ] `bash scripts/cloud_bootstrap.sh`
+- [ ] Implement boss mechanics/arenas/loot
+- [ ] `./gradlew :forge:runData`
+- [ ] `./gradlew check`
+- [ ] Log entry `progress/stepXX_exotica_bosses.md` + `PROGRESS_PROMPTS.md`
+- [ ] Open PR referencing this task file

--- a/tasks/2025-09-21/T-114_exotica-hazards.md
+++ b/tasks/2025-09-21/T-114_exotica-hazards.md
@@ -1,0 +1,21 @@
+# T-114 Exotica Hazards & Visuals
+
+**Goal**
+- Implement Exotica environmental effects: random spatial distortions/short-range teleports, quantum glade refraction debuffs, fractal gravity fluctuations, colour-cycling skybox, and phasing ambient mobs/particles.
+
+**Scope**
+- Hazard systems tied to suit/tech checks (teleport resistance, nausea mitigation) with config knobs.
+- Visual/audio layers for chromatic haze, light refraction shaders, resonance hum loops, and biome-specific particle FX.
+- Gravity modifier hooks that fluctuate in Fractal Forest zones.
+
+**Acceptance**
+- Hazards trigger in appropriate biomes with tuning exposed; players can mitigate via config/suit tier; visuals/audio match design doc references.
+- `./gradlew check` passes; capture tuning notes in progress log.
+
+**Checklist**
+- [ ] `bash scripts/cloud_bootstrap.sh`
+- [ ] Implement hazard/visual systems
+- [ ] `./gradlew :common:spotlessApply :forge:spotlessApply`
+- [ ] `./gradlew check`
+- [ ] Log entry `progress/stepXX_exotica_hazards.md` + `PROGRESS_PROMPTS.md`
+- [ ] Open PR referencing this task file

--- a/tasks/2025-09-21/T-120_torusworld-generator-biomes.md
+++ b/tasks/2025-09-21/T-120_torusworld-generator-biomes.md
@@ -1,0 +1,21 @@
+# T-120 Torus World Generator & Biomes
+
+**Goal**
+- Implement Torus World custom generator with wrap-around toroidal layout and biome suite (Inner Rim Forest, Outer Rim Desert, Structural Spine, Radiant Fields, Null-G Hubs) matching gravity gradients.
+
+**Scope**
+- Chunk generator/density functions for toroidal geometry, including inner/outer rim gravity metadata and null-g zones.
+- Dimension + biome JSONs with engineered skybox, lighting, and biome ambience per design doc.
+- Biome tag setup for GT ore layers and hazard routing.
+
+**Acceptance**
+- Terrain produces continuous torus with seamless wrap; biome bands align with intended regions and gravity metadata surfaces to mechanics systems.
+- `./gradlew :forge:runData` + `./gradlew check` pass.
+
+**Checklist**
+- [ ] `bash scripts/cloud_bootstrap.sh`
+- [ ] Implement generator + biome files
+- [ ] `./gradlew :forge:runData`
+- [ ] `./gradlew check`
+- [ ] Log entry `progress/stepXX_torusworld_generator.md` + `PROGRESS_PROMPTS.md`
+- [ ] Open PR referencing this task file

--- a/tasks/2025-09-21/T-121_torusworld-blocks-features.md
+++ b/tasks/2025-09-21/T-121_torusworld-blocks-features.md
@@ -1,0 +1,21 @@
+# T-121 Torus World Blocks & Features
+
+**Goal**
+- Implement Torus World blocks (Torium Alloy Blocks, Radiant Panels, Structural Lattice, Torium Grass, Forest Alloy Soil, Desert Alloy Sand, Reflective Stone, Spine Alloy, Rotary Plates, Pulse Nodes, Exotic Alloy Blocks, Null Nodes) and associated flora/features (Spiral Trees, Light Moss, Spine Palms, Glow Cacti, gravity vines, floating debris).
+
+**Scope**
+- Block/item registrations with metallic/animated materials and emissive textures where required.
+- Configured/placed features for flora, floating debris clusters, radiation pulse nodes, and null-g flora.
+- Integration with biome modifiers to place engineering set pieces per zone.
+
+**Acceptance**
+- Blocks render with correct materials/emission; features populate intended biomes (forest, desert, spine, radiant fields, null hubs).
+- `./gradlew :forge:runData` + `./gradlew check` pass.
+
+**Checklist**
+- [ ] `bash scripts/cloud_bootstrap.sh`
+- [ ] Implement blocks/features + assets
+- [ ] `./gradlew :forge:runData`
+- [ ] `./gradlew check`
+- [ ] Log entry `progress/stepXX_torusworld_features.md` + `PROGRESS_PROMPTS.md`
+- [ ] Open PR referencing this task file

--- a/tasks/2025-09-21/T-122_torusworld-entities.md
+++ b/tasks/2025-09-21/T-122_torusworld-entities.md
@@ -1,0 +1,21 @@
+# T-122 Torus World Entities
+
+**Goal**
+- Implement Torus World entity roster: Rim Grazers, Light Owls, Sand Striders, Solar Stalkers, Maintenance Drones, Alloy Serpents, Radiant Beasts, Pulse Wraiths, Void Eels, Null Phantoms plus mini-bosses (Forest Guardian, Desert Colossus, Spine Overseer, Luminal Titan, Exotic Horror).
+
+**Scope**
+- Entity classes, AI, animation, spawn rules, loot tables delivering GT materials (alloy horns, solar scales, circuit fragments, pulse essence, null essence).
+- Mini-boss ability scripting (root entangle, sandstorm, platform destabilization, radiant beams, micro singularities) and arena triggers.
+- Null-G movement handling for hubs and gravity-shift behaviours in other zones.
+
+**Acceptance**
+- Entities behave per design doc (gravity-aware motion, radiation pulses, drone swarms) and spawn in correct biomes; drops feed GT exotic matter progression.
+- `./gradlew check` passes; note outstanding animation/polish tasks in progress log.
+
+**Checklist**
+- [ ] `bash scripts/cloud_bootstrap.sh`
+- [ ] Implement entities + assets
+- [ ] `./gradlew :common:spotlessApply :forge:spotlessApply`
+- [ ] `./gradlew check`
+- [ ] Log entry `progress/stepXX_torusworld_entities.md` + `PROGRESS_PROMPTS.md`
+- [ ] Open PR referencing this task file

--- a/tasks/2025-09-21/T-123_torusworld-boss.md
+++ b/tasks/2025-09-21/T-123_torusworld-boss.md
@@ -1,0 +1,21 @@
+# T-123 Torus Warden Boss Encounter
+
+**Goal**
+- Implement the Torus Warden main boss (Structural Defense → Gravity Collapse → Singularity Protocol) with rotating platform arena, gravity shift mechanics, and rewards (Torus Core, Warden’s Ringblade, Null Circuit Core).
+
+**Scope**
+- Boss entity behaviour: drone summons, gravity flip scheduling, micro black hole pull, beam attacks.
+- Central gyroscopic hub arena structure with moving platforms, collapse cues, and hazard scripting.
+- Loot/progression integration linking Torus Core + other drops into GT exotic matter unlocks.
+
+**Acceptance**
+- Boss runs all phases reliably with gravity transitions and platform motion matching design doc; rewards granted and recorded in progression configs.
+- `./gradlew :forge:runData` (if structures) + `./gradlew check` pass.
+
+**Checklist**
+- [ ] `bash scripts/cloud_bootstrap.sh`
+- [ ] Implement boss mechanics/arena/loot
+- [ ] `./gradlew :forge:runData`
+- [ ] `./gradlew check`
+- [ ] Log entry `progress/stepXX_torusworld_boss.md` + `PROGRESS_PROMPTS.md`
+- [ ] Open PR referencing this task file

--- a/tasks/2025-09-21/T-124_torusworld-hazards.md
+++ b/tasks/2025-09-21/T-124_torusworld-hazards.md
@@ -1,0 +1,21 @@
+# T-124 Torus World Hazards & Progression Hooks
+
+**Goal**
+- Implement Torus World systemic hazards: regional gravity shifts, structural collapse traps in the spine, periodic radiation pulses in Radiant Fields, and null-g navigation aids; document GT progression hooks (Forest/Desert/Spine/Radiant/Exotic cores, Torus Core).
+
+**Scope**
+- Hazard controllers tied to biome regions adjusting gravity, damage, and movement.
+- Radiation pulse scheduler, debris fall logic, and null-g movement toggles.
+- Progression config updates enumerating required cores/hearts for GT unlock matrix.
+
+**Acceptance**
+- Hazards trigger in appropriate zones with configurable intensity; suits/tech gating enforced; progression docs updated.
+- `./gradlew check` passes; notes recorded for balancing.
+
+**Checklist**
+- [ ] `bash scripts/cloud_bootstrap.sh`
+- [ ] Implement hazard/progression systems
+- [ ] `./gradlew :common:spotlessApply :forge:spotlessApply`
+- [ ] `./gradlew check`
+- [ ] Log entry `progress/stepXX_torusworld_hazards.md` + `PROGRESS_PROMPTS.md`
+- [ ] Open PR referencing this task file

--- a/tasks/2025-09-21/T-130_hollowworld-dimension-biomes.md
+++ b/tasks/2025-09-21/T-130_hollowworld-dimension-biomes.md
@@ -1,0 +1,21 @@
+# T-130 Hollow World Dimension & Biomes
+
+**Goal**
+- Define Hollow World inverted dimension with biomes (Bioluminescent Caverns, Void Chasms, Crystal Groves, Stalactite Forest, Subterranean Rivers) and inverted gravity visuals.
+
+**Scope**
+- Dimension JSON/noise for inner-shell terrain, void chasm carving, glowing sky/ceiling.
+- Biome JSONs capturing lighting (biolume patches, darkness pockets), hazard flags, and ambience per biome.
+- Biome tags for ore layers and hazard routing.
+
+**Acceptance**
+- Dimension loads with inverted gravity cues and biome placement matching design doc; debug worldgen shows each biome.
+- `./gradlew :forge:runData` + `./gradlew check` pass.
+
+**Checklist**
+- [ ] `bash scripts/cloud_bootstrap.sh`
+- [ ] Author dimension/biome files
+- [ ] `./gradlew :forge:runData`
+- [ ] `./gradlew check`
+- [ ] Log entry `progress/stepXX_hollowworld_biomes.md` + `PROGRESS_PROMPTS.md`
+- [ ] Open PR referencing this task file

--- a/tasks/2025-09-21/T-131_hollowworld-blocks-features.md
+++ b/tasks/2025-09-21/T-131_hollowworld-blocks-features.md
@@ -1,0 +1,21 @@
+# T-131 Hollow World Blocks & Features
+
+**Goal**
+- Implement Hollow World block sets (Hollowstone variants, Biolume Moss, Fungal Stone, Voidstone/Void Crystals, Crystal Bark/Prism Stone, Stalactite variants, Riverbed stone) and flora/features (Glowshrooms, Spore Reeds, Shadow Vines, Crystal Trees, Shard Flowers, hanging stalactite forests, biolum river flora).
+
+**Scope**
+- Block registrations with emissive/glowing materials, hanging variants, and flowing river assets.
+- Configured/placed features for cavern mushrooms, void chasm platforms, crystal groves, stalactite forests, subterranean river vegetation.
+- Loot tables/recipes for new blocks aligning with GT processing.
+
+**Acceptance**
+- Features populate intended biomes with lighting/hazard behaviour (void crystals glow, stalactites hang, moss emits light).
+- `./gradlew :forge:runData` + `./gradlew check` pass.
+
+**Checklist**
+- [ ] `bash scripts/cloud_bootstrap.sh`
+- [ ] Implement blocks/features + assets
+- [ ] `./gradlew :forge:runData`
+- [ ] `./gradlew check`
+- [ ] Log entry `progress/stepXX_hollowworld_features.md` + `PROGRESS_PROMPTS.md`
+- [ ] Open PR referencing this task file

--- a/tasks/2025-09-21/T-132_hollowworld-entities.md
+++ b/tasks/2025-09-21/T-132_hollowworld-entities.md
@@ -1,0 +1,21 @@
+# T-132 Hollow World Entities
+
+**Goal**
+- Implement Hollow World entities: Spore Beasts, Lume Bats, Void Phantoms, Chasm Serpents, Shardlings, Prism Stalkers, Root Spiders, Hollow Stalkers, River Serpents, Lume Fish plus mini-bosses (Mycelium Horror, Abyss Wyrm, Crystal Titan, Stalactite Horror, River Leviathan).
+
+**Scope**
+- Entity classes, AI, spawn rules, loot tables delivering GT biochemical/void/crystal materials (spore glands, bat oil, void essence, chasm scales, crystal dust, prism pelts, root silk, stalker fangs, serpent oil).
+- Mini-boss ability scripting (spore clouds, void shockwaves, light refraction, stalactite collapse, river whirlpools) with arena triggers.
+- Support for inverted gravity pathing and void edge avoidance.
+
+**Acceptance**
+- Entities spawn and behave per biome requirements (flying in caverns, void-lurking serpents, river apex predators) with drop tables matching GT unlocks.
+- `./gradlew check` passes; log outstanding FX/animation tasks.
+
+**Checklist**
+- [ ] `bash scripts/cloud_bootstrap.sh`
+- [ ] Implement entities + assets
+- [ ] `./gradlew :common:spotlessApply :forge:spotlessApply`
+- [ ] `./gradlew check`
+- [ ] Log entry `progress/stepXX_hollowworld_entities.md` + `PROGRESS_PROMPTS.md`
+- [ ] Open PR referencing this task file

--- a/tasks/2025-09-21/T-133_hollowworld-boss.md
+++ b/tasks/2025-09-21/T-133_hollowworld-boss.md
@@ -1,0 +1,21 @@
+# T-133 Hollow Tyrant Boss Encounter
+
+**Goal**
+- Implement the Hollow Tyrant main boss (Fungal Wrath → Crystal Dominion → Void Phase) with spherical arena, inverted gravity combat, and rewards (Hollow Heart, Tyrant Fangblade, Tyrant Core).
+
+**Scope**
+- Boss entity behaviour: spore cloud summons, crystal spike growth, void platform collapse.
+- Central cavern arena structure with inverted walkable surfaces and collapsible sections.
+- Loot/progression integration mapping Hollow Heart + associated drops into GT void catalyst chain.
+
+**Acceptance**
+- Fight executes all phases with inverted gravity mechanics and hazard transitions; rewards delivered and progression hooks validated.
+- `./gradlew :forge:runData` (if structures) + `./gradlew check` pass.
+
+**Checklist**
+- [ ] `bash scripts/cloud_bootstrap.sh`
+- [ ] Implement boss mechanics/arena/loot
+- [ ] `./gradlew :forge:runData`
+- [ ] `./gradlew check`
+- [ ] Log entry `progress/stepXX_hollowworld_boss.md` + `PROGRESS_PROMPTS.md`
+- [ ] Open PR referencing this task file

--- a/tasks/2025-09-21/T-134_hollowworld-hazards.md
+++ b/tasks/2025-09-21/T-134_hollowworld-hazards.md
@@ -1,0 +1,21 @@
+# T-134 Hollow World Hazards & Atmospherics
+
+**Goal**
+- Implement Hollow World hazards: darkness patches extinguishing light, void chasm instakill zones, crystal grove radiation bursts, inverted gravity cues, and biolum ambience.
+
+**Scope**
+- Hazard controllers for darkness debuffs, void boundary checks, radiation pulses, and inverted gravity effects.
+- Lighting/particle/audio work (biolum glow, void hum, crystal resonance) plus skybox adjustments.
+- Config/progression updates documenting suit requirements and core unlock mapping (Fungal/Void/Crystal/Stalactite/River/Hollow Heart).
+
+**Acceptance**
+- Hazards operate in correct biomes with mitigation options (suits, equipment) and logging for balancing; ambience matches design doc.
+- `./gradlew check` passes; update notes with tuning data.
+
+**Checklist**
+- [ ] `bash scripts/cloud_bootstrap.sh`
+- [ ] Implement hazard/atmosphere systems
+- [ ] `./gradlew :common:spotlessApply :forge:spotlessApply`
+- [ ] `./gradlew check`
+- [ ] Log entry `progress/stepXX_hollowworld_hazards.md` + `PROGRESS_PROMPTS.md`
+- [ ] Open PR referencing this task file

--- a/tasks/2025-09-21/T-140_dysonswarm-dimension-biomes.md
+++ b/tasks/2025-09-21/T-140_dysonswarm-dimension-biomes.md
@@ -1,0 +1,21 @@
+# T-140 Shattered Dyson Swarm Dimension & Biomes
+
+**Goal**
+- Define the Shattered Dyson Swarm zero-G dimension with biome set (Panel Fields, Broken Node Clusters, Scaffold Rings, Shadow Wedges, Relay Lattices) and vacuum conditions.
+
+**Scope**
+- Dimension JSON/noise for orbital debris fields, sun-facing lighting, zero-G configuration.
+- Biome JSONs with vacuum atmosphere flags, radiation lighting, particle FX, and structure placements per design doc.
+- Biome tags for ore distribution and hazard routing.
+
+**Acceptance**
+- Datapack loads with zero-G/vacuum behaviour exposed to mechanics; debug worldgen shows each biome variant with correct ambience.
+- `./gradlew :forge:runData` + `./gradlew check` pass.
+
+**Checklist**
+- [ ] `bash scripts/cloud_bootstrap.sh`
+- [ ] Author dimension/biome files
+- [ ] `./gradlew :forge:runData`
+- [ ] `./gradlew check`
+- [ ] Log entry `progress/stepXX_dysonswarm_biomes.md` + `PROGRESS_PROMPTS.md`
+- [ ] Open PR referencing this task file

--- a/tasks/2025-09-21/T-141_dysonswarm-structures-blocks.md
+++ b/tasks/2025-09-21/T-141_dysonswarm-structures-blocks.md
@@ -1,0 +1,21 @@
+# T-141 Shattered Dyson Swarm Blocks & Structures
+
+**Goal**
+- Implement Dyson Swarm block set (Dyson Panels/Damaged Panels, Node Fragments, Circuit Blocks, Scaffold Struts, Rotary Nodes, Shadow Panels, Irradiated Stone, Relay Nodes, Signal Struts) and structural pieces (floating panel arrays, broken node clusters, scaffold lattice segments, shadow wedges, relay towers) per design doc.
+
+**Scope**
+- Block registrations with reflective/emissive materials, animated circuitry, and radiation emissivity.
+- Structure templates/processors for debris fields, panel stacks, relay towers, shielded shadow shelters; placement integration.
+- Optional photonic fungi/ambient feature hooks referenced in doc.
+
+**Acceptance**
+- Blocks render with required materials; structures spawn in intended biomes with rotation/spacing validated.
+- `./gradlew :forge:runData` + `./gradlew check` pass.
+
+**Checklist**
+- [ ] `bash scripts/cloud_bootstrap.sh`
+- [ ] Implement blocks/structures + assets
+- [ ] `./gradlew :forge:runData`
+- [ ] `./gradlew check`
+- [ ] Log entry `progress/stepXX_dysonswarm_structures.md` + `PROGRESS_PROMPTS.md`
+- [ ] Open PR referencing this task file

--- a/tasks/2025-09-21/T-142_dysonswarm-entities.md
+++ b/tasks/2025-09-21/T-142_dysonswarm-entities.md
@@ -1,0 +1,21 @@
+# T-142 Shattered Dyson Swarm Entities
+
+**Goal**
+- Implement Dyson Swarm fauna/constructs: Solar Moths, Panel Crawlers, Node Wraiths, Repair Drones, Scaffold Serpents, Orb Drones, Radiation Wraiths, Shadow Hounds, Signal Phantoms, Relay Constructs plus mini-bosses (Solar Warden, Node Horror, Scaffold Titan, Radiant Abomination, Signal Overlord).
+
+**Scope**
+- Entity classes with zero-G movement/AI, loot tables (photon scales, panel shards, node essence, circuit parts, scaffold scales, drone alloys, rad essence, hound fangs, signal dust, relay shards).
+- Mini-boss ability scripting (blinding flashes, EMP pulses, collapsing scaffolds, radiation bursts, HUD overload) and arena triggers.
+- Vacuum survival hooks ensuring mobs operate without atmosphere.
+
+**Acceptance**
+- Entities spawn/behave per biome (zero-G drift, scaffold traversal, radiation zones) and drops feed GT photonics/radiation/quantum unlocks.
+- `./gradlew check` passes; log outstanding animation/FX tasks.
+
+**Checklist**
+- [ ] `bash scripts/cloud_bootstrap.sh`
+- [ ] Implement entities + assets
+- [ ] `./gradlew :common:spotlessApply :forge:spotlessApply`
+- [ ] `./gradlew check`
+- [ ] Log entry `progress/stepXX_dysonswarm_entities.md` + `PROGRESS_PROMPTS.md`
+- [ ] Open PR referencing this task file

--- a/tasks/2025-09-21/T-143_dysonswarm-boss.md
+++ b/tasks/2025-09-21/T-143_dysonswarm-boss.md
@@ -1,0 +1,21 @@
+# T-143 Dyson Apex Boss Encounter
+
+**Goal**
+- Implement the Dyson Apex boss (Solar Flare → Overload → Collapse) with zero-G arena, plasma arcs, collapsing panels, and rewards (Apex Core, Dyson Spear, Quantum Lens).
+
+**Scope**
+- Boss entity behaviour: plasma bolt barrages, EMP debuffs, platform destruction scheduling.
+- Shattered node arena structure with zero-G movement rules and dynamic panel collapse.
+- Loot/progression integration hooking Apex Core and other drops into GT stellar power unlocks.
+
+**Acceptance**
+- Encounter executes all phases with zero-G mechanics and dynamic panel hazards; rewards granted and progression wiring validated.
+- `./gradlew :forge:runData` (if structures) + `./gradlew check` pass.
+
+**Checklist**
+- [ ] `bash scripts/cloud_bootstrap.sh`
+- [ ] Implement boss mechanics/arena/loot
+- [ ] `./gradlew :forge:runData`
+- [ ] `./gradlew check`
+- [ ] Log entry `progress/stepXX_dysonswarm_boss.md` + `PROGRESS_PROMPTS.md`
+- [ ] Open PR referencing this task file

--- a/tasks/2025-09-21/T-144_dysonswarm-hazards.md
+++ b/tasks/2025-09-21/T-144_dysonswarm-hazards.md
@@ -1,0 +1,21 @@
+# T-144 Shattered Dyson Swarm Hazards & Progression
+
+**Goal**
+- Implement Dyson Swarm hazards: timed solar radiation bursts, debris collisions, vacuum exposure checks, zero-G navigation aids, and document progression hooks (Solar/Node/Scaffold/Radiant/Relay cores, Apex Core).
+
+**Scope**
+- Hazard controllers for radiation pulses, debris spawn/destruction, and suit requirement checks.
+- Zero-G movement assistance modules and optional thruster integration.
+- Progression config updates and documentation linking cores/hearts to GT unlocks.
+
+**Acceptance**
+- Hazards operate on schedule with mitigation pathways (shield modules, shelters) and feed telemetry; progression docs updated.
+- `./gradlew check` passes; note balancing data in progress log.
+
+**Checklist**
+- [ ] `bash scripts/cloud_bootstrap.sh`
+- [ ] Implement hazard/progression systems
+- [ ] `./gradlew :common:spotlessApply :forge:spotlessApply`
+- [ ] `./gradlew check`
+- [ ] Log entry `progress/stepXX_dysonswarm_hazards.md` + `PROGRESS_PROMPTS.md`
+- [ ] Open PR referencing this task file

--- a/tasks/2025-09-21/T-150_neutronforge-dimension-biomes.md
+++ b/tasks/2025-09-21/T-150_neutronforge-dimension-biomes.md
@@ -1,0 +1,21 @@
+# T-150 Neutron Star Forge Dimension & Biomes
+
+**Goal**
+- Define Neutron Star Forge dimension with extreme gravity/radiation and biomes (Accretion Rim, Magnetar Belts, Forge Platforms, Gravity Wells, Radiation Shelters).
+
+**Scope**
+- Dimension JSON/noise for neutron star proximity, gravity scaling, plasma lighting.
+- Biome JSONs detailing hazards, fog, ambience, and block palettes per biome.
+- Biome tags for ore/hazard distribution.
+
+**Acceptance**
+- Dimension loads with intended gravity/radiation metadata; each biome spawns via debug worldgen with correct ambience.
+- `./gradlew :forge:runData` + `./gradlew check` pass.
+
+**Checklist**
+- [ ] `bash scripts/cloud_bootstrap.sh`
+- [ ] Author dimension/biome files
+- [ ] `./gradlew :forge:runData`
+- [ ] `./gradlew check`
+- [ ] Log entry `progress/stepXX_neutronforge_biomes.md` + `PROGRESS_PROMPTS.md`
+- [ ] Open PR referencing this task file

--- a/tasks/2025-09-21/T-151_neutronforge-blocks-features.md
+++ b/tasks/2025-09-21/T-151_neutronforge-blocks-features.md
@@ -1,0 +1,21 @@
+# T-151 Neutron Star Forge Blocks & Features
+
+**Goal**
+- Implement Neutron Star Forge block families (Accretion Rock, Plasma Glass, Magnetite Alloy Blocks, Charge Crystals, Forge Alloy Blocks, Furnace Nodes, Neutron Stone, Strangelet Blocks, Radiation Alloy, Shield Panels) and related features.
+
+**Scope**
+- Block registrations with emissive/animated materials, high-resistance properties, and radiation shielding tags.
+- Configured/placed features for plasma ejection vents, magnetic storms, forge platforms, gravity well effects, radiation shelter interiors.
+- Loot/recipe integration for new blocks aligning with GT processing chains.
+
+**Acceptance**
+- Blocks and features appear in correct biomes with intended behaviour (plasma glow, magnetic sparks, gravity well visuals).
+- `./gradlew :forge:runData` + `./gradlew check` pass.
+
+**Checklist**
+- [ ] `bash scripts/cloud_bootstrap.sh`
+- [ ] Implement blocks/features + assets
+- [ ] `./gradlew :forge:runData`
+- [ ] `./gradlew check`
+- [ ] Log entry `progress/stepXX_neutronforge_features.md` + `PROGRESS_PROMPTS.md`
+- [ ] Open PR referencing this task file

--- a/tasks/2025-09-21/T-152_neutronforge-entities.md
+++ b/tasks/2025-09-21/T-152_neutronforge-entities.md
@@ -1,0 +1,21 @@
+# T-152 Neutron Star Forge Entities
+
+**Goal**
+- Implement Neutron Star Forge entities: Plasma Eels, Accretion Beasts, Magnetar Serpents, Storm Constructs, Forge Drones, Smelter Horrors, Gravity Horrors, Void Leeches, Shelter Guardians, Radiant Wraiths plus mini-bosses (Accretion Leviathan, Magnetar Colossus, Forge Overseer, Graviton Horror, Shelter Sentinel).
+
+**Scope**
+- Entity classes, AI, animations, loot tables with GT drops (plasma organs, accreted cores, magnetar scales, storm fragments, alloy chips, molten organs, gravity organs, leech extracts, shield circuits, radiant essence).
+- Mini-boss ability scripting (plasma waves, magnetic disarm, drone summons, gravitational collapses, radiation shields) with arena triggers.
+- High-gravity movement handling, radiation immunity, and equipment disruption logic.
+
+**Acceptance**
+- Entities spawn/behave per biome with gravity/radiation effects and drop tables aligned to GT unlocks.
+- `./gradlew check` passes; document outstanding FX/animation items.
+
+**Checklist**
+- [ ] `bash scripts/cloud_bootstrap.sh`
+- [ ] Implement entities + assets
+- [ ] `./gradlew :common:spotlessApply :forge:spotlessApply`
+- [ ] `./gradlew check`
+- [ ] Log entry `progress/stepXX_neutronforge_entities.md` + `PROGRESS_PROMPTS.md`
+- [ ] Open PR referencing this task file

--- a/tasks/2025-09-21/T-153_neutronforge-boss.md
+++ b/tasks/2025-09-21/T-153_neutronforge-boss.md
@@ -1,0 +1,21 @@
+# T-153 Forge Star Sovereign Boss Encounter
+
+**Goal**
+- Implement the Forge Star Sovereign boss (Magnetic Phase → Plasma Phase → Collapse Phase) with molten arena, magnetic disarm mechanics, and rewards (Sovereign Heart, Neutron Edge, Forge Matrix Core).
+
+**Scope**
+- Boss entity behaviour: weapon disarm, plasma beam volleys, gravitational collapse events.
+- Forge platform arena structure with molten floor transitions and collapse scripting.
+- Loot/progression integration linking drops to GT neutronium/exotic reactor unlocks.
+
+**Acceptance**
+- Encounter runs through all phases with magnetic/plasma/gravity mechanics functioning; rewards applied to progression configs.
+- `./gradlew :forge:runData` (if structures) + `./gradlew check` pass.
+
+**Checklist**
+- [ ] `bash scripts/cloud_bootstrap.sh`
+- [ ] Implement boss mechanics/arena/loot
+- [ ] `./gradlew :forge:runData`
+- [ ] `./gradlew check`
+- [ ] Log entry `progress/stepXX_neutronforge_boss.md` + `PROGRESS_PROMPTS.md`
+- [ ] Open PR referencing this task file

--- a/tasks/2025-09-21/T-154_neutronforge-hazards.md
+++ b/tasks/2025-09-21/T-154_neutronforge-hazards.md
@@ -1,0 +1,21 @@
+# T-154 Neutron Star Forge Hazards & Progression
+
+**Goal**
+- Implement Neutron Star Forge hazards: magnetic storms disrupting equipment, radiation bursts, gravity wells pulling players, plasma eruptions, and progression documentation (Accretion/Magnetar/Forge/Graviton/Shelter cores, Sovereign Heart).
+
+**Scope**
+- Hazard controllers for magnetic disarms, radiation tick damage, gravity well pulls, plasma eruptions, and suit requirement checks.
+- Audio/visual FX (magnetic arcs, plasma flares, gravity distortion) and telemetry logging.
+- Progression config updates tying cores/hearts to GT unlocks and suit thresholds.
+
+**Acceptance**
+- Hazards trigger per biome with mitigation options (shielding, anchoring) and log outputs; progression documentation refreshed.
+- `./gradlew check` passes; balancing notes recorded.
+
+**Checklist**
+- [ ] `bash scripts/cloud_bootstrap.sh`
+- [ ] Implement hazard/progression systems
+- [ ] `./gradlew :common:spotlessApply :forge:spotlessApply`
+- [ ] `./gradlew check`
+- [ ] Log entry `progress/stepXX_neutronforge_hazards.md` + `PROGRESS_PROMPTS.md`
+- [ ] Open PR referencing this task file


### PR DESCRIPTION
## Summary
- add TASK_TRACKING.md to consolidate task progress across core systems and every planet
- refresh Pandora, Crystalis, Stormworld, and Ringworld task briefs to match the latest planet design details
- author new Exotica, Torus World, Hollow World, Shattered Dyson Swarm, and Neutron Star Forge task files covering dimension setup, content, bosses, and hazards

## Testing
- not run (docs only)


------
https://chatgpt.com/codex/tasks/task_e_68d14f7e9d2c832994b0490ec26e010f